### PR TITLE
fix : build.gradle 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,7 @@ asciidoctor {
 	inputs.dir snippetsDir
 	dependsOn test
 }
+
+jar	{
+	enabled = false
+}


### PR DESCRIPTION
스프링부트 2.5.0 이상의 버전에서 build시 jar 파일이 2개 생기게 변경됨
jar:enable=false를 설정해서 jar 파일이 하나만 만들어지도록 설정했습니다.