### PR TITLE
fix : 듀오 리스트의 키 값을 data로 변경

### DIFF
--- a/src/main/java/com/lolup/lolup_project/duo/DuoService.java
+++ b/src/main/java/com/lolup/lolup_project/duo/DuoService.java
@@ -6,10 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @Transactional
@@ -20,11 +17,11 @@ public class DuoService {
     private final SummonerService summonerService;
 
     public Map<String, Object> findAll(String position, String tier, int section) {
-        List<DuoDto> list = duoRepository.findAll(position, tier, (section * 20));
+        List<DuoDto> data = duoRepository.findAll(position, tier, (section * 20));
 
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("totalCount", duoRepository.getTotalCount());
-        map.put("list", list);
+        map.put("data", data);
 
         return map;
     }

--- a/src/test/java/com/lolup/lolup_project/duo/DuoControllerTest.java
+++ b/src/test/java/com/lolup/lolup_project/duo/DuoControllerTest.java
@@ -125,9 +125,9 @@ class DuoControllerTest {
                         ),
                         responseFields(
                                 fieldWithPath("totalCount").description("DB에 저장된 총 듀오 데이터 수"),
-                                subsectionWithPath("list").type("List<DuoDto>").description("페이징 처리된 듀오 리스트")
+                                subsectionWithPath("data").type("List<DuoDto>").description("페이징 처리된 듀오 리스트")
                         ),
-                        responseFields(beneathPath("list"),
+                        responseFields(beneathPath("data"),
                                 fieldWithPath("duoId").type("Long").description("작성한 모집글의 고유 번호"),
                                 fieldWithPath("memberId").type("Long").description("작성자의 회원 고유 번호"),
                                 fieldWithPath("iconId").type("int").description("프로필 아이콘 번호"),
@@ -149,16 +149,16 @@ class DuoControllerTest {
     private Map<String, Object> getDuoMap() {
         DuoDto duoDto1 = getDuoDto();
         DuoDto duoDto2 = getDuoDto();
-        List<DuoDto> list = new ArrayList<>();
-        list.add(duoDto1);
-        list.add(duoDto2);
+        List<DuoDto> data = new ArrayList<>();
+        data.add(duoDto1);
+        data.add(duoDto2);
 
         int totalCount = 100;
-        int listSize = list.size();
+        int listSize = data.size();
 
         Map<String, Object> map = new HashMap<>();
         map.put("totalCount", totalCount);
-        map.put("list", list);
+        map.put("data", data);
 
         return map;
     }


### PR DESCRIPTION
프론트 서버에서 datatables의 그리드를 구성하게 될 데이터가 담겨있는 리스트는
반드시 "data" 라는 이름으로 전달받아야한다.